### PR TITLE
Improve hero typewriter speed

### DIFF
--- a/src/components/sections/HeroSection.js
+++ b/src/components/sections/HeroSection.js
@@ -42,10 +42,17 @@ const TypewriterEffect = ({ text, delay = 0 }) => {
 
   useEffect(() => {
     if (currentIndex < text.length) {
+      const baseSpeed = 50; // velocidade inicial em ms
+      const minSpeed = 30; // velocidade mínima em ms
+      const letterDelay =
+        currentIndex === 0
+          ? delay
+          : Math.max(minSpeed, baseSpeed - currentIndex * 2); // leve aceleração
+
       const timer = setTimeout(() => {
         setDisplayText(prev => prev + text[currentIndex]);
         setCurrentIndex(prev => prev + 1);
-      }, delay + currentIndex * 80); // Velocidade ajustada para melhor visualização
+      }, letterDelay);
 
       return () => clearTimeout(timer);
     }

--- a/src/config/portfolio.js
+++ b/src/config/portfolio.js
@@ -10,7 +10,7 @@
 export const personalInfo = {
   name: "Tiago da Silva e Santo",
   fullName: "Tiago Da Silva E Santo",
-  title: "Full Stack em Dados e Analytics — da coleta ao insight estratégico.",
+  title: "Full Stack em Dados e Analytics",
   subtitle: "Transformando dados em insights estratégicos para negócios",
   location: "São Paulo, SP",
   email: "tiagomars233@gmail.com",


### PR DESCRIPTION
## Summary
- speed up typewriter animation
- shorten job title line

## Testing
- `CI=true npm test --silent` *(fails: MUI theme error)*

------
https://chatgpt.com/codex/tasks/task_e_688be3801b5883288cfccc627b8119cc