### PR TITLE
fix: disable puppeteer sandbox

### DIFF
--- a/scripts/generate-og.js
+++ b/scripts/generate-og.js
@@ -37,6 +37,7 @@ async function generate() {
   const browser = await puppeteer.launch({
     headless: 'new',
     defaultViewport: { width: 1200, height: 630, deviceScaleFactor: 2 },
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
   });
   const page = await browser.newPage();
 


### PR DESCRIPTION
## Summary
- allow Puppeteer to run without sandbox in generate-og script

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1d6aaed1c8328b79aeb3d2250b88c